### PR TITLE
fix: stabilize Windows packaging checks

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  PYTHONUTF8: "1"
+
 jobs:
   check:
     strategy:

--- a/tests/test_claude_runtime_sync.py
+++ b/tests/test_claude_runtime_sync.py
@@ -83,7 +83,7 @@ class BootstrapWorkspaceTests(unittest.TestCase):
             )
             self.assertFalse((plugin_data / "runtime" / "scripts" / "removed.ts").exists())
             self.assertEqual(1, len(calls))
-            self.assertEqual(plugin_data, calls[0][1])
+            self.assertEqual(plugin_data.resolve(), calls[0][1])
             self.assertIn("ci", calls[0][0])
 
             write(runtime_root / "package.json", '{"name":"test","version":"1.0.1"}\n')


### PR DESCRIPTION
## Summary
- run Python in UTF-8 mode in Packaging checks
- compare the canonical plugin-data path in the runtime preparation test

## Root cause
Windows runners used a legacy console encoding that could not print Chinese CLI output. The runner temp directory could also be represented by both an 8.3 short path and its canonical long path, causing a false path inequality in one test.

## Verification
- targeted five previously failing tests: passed
- Windows junction alias reproduction: passed after fix
- `npm run check`: 177 passed, 1 skipped; all validators passed
- `npm audit --omit=dev --audit-level=high`: passed (one existing low-severity advisory)
- isolated plugin installation: passed